### PR TITLE
Add Prefect orchestration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,22 @@
-# Placeholder
+# Project Documentation
+
+## Orchestration
+
+This project uses **Prefect** to orchestrate the data ingestion, model training
+and deployment tasks.
+
+### Running the orchestrator
+
+1. Install the project dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Execute the flow using the pipeline entry point:
+
+   ```bash
+   python src/pipeline.py
+   ```
+
+The `main_flow` defined in `src/orchestrator.py` will run each task in order.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ xgboost
 scikit-learn
 pandas
 numpy
+prefect

--- a/src/ingestion/load_data.py
+++ b/src/ingestion/load_data.py
@@ -1,1 +1,5 @@
-# Load Data.Py
+"""Data ingestion utilities."""
+
+def run() -> None:
+    """Placeholder for data ingestion logic."""
+    print("Ingesting data...")

--- a/src/modeling/opti_shift.py
+++ b/src/modeling/opti_shift.py
@@ -1,1 +1,5 @@
-# Opti Shift.Py
+"""Model training utilities."""
+
+def train() -> None:
+    """Placeholder for model training."""
+    print("Training model...")

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -1,0 +1,32 @@
+from prefect import flow, task
+
+from ingestion.load_data import run as ingest_run
+from modeling.opti_shift import train as model_train
+from scoring.api import deploy as deploy_api
+
+
+@task
+def ingest():
+    ingest_run()
+
+
+@task
+def train():
+    model_train()
+
+
+@task
+def deploy():
+    deploy_api()
+
+
+@flow
+def main_flow():
+    """Orchestrate ingestion, training and deployment tasks."""
+    ingest()
+    train()
+    deploy()
+
+
+if __name__ == "__main__":
+    main_flow()

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,0 +1,6 @@
+"""Entry point for running the Prefect flow."""
+
+from orchestrator import main_flow
+
+if __name__ == "__main__":
+    main_flow()

--- a/src/scoring/api.py
+++ b/src/scoring/api.py
@@ -1,1 +1,5 @@
-# Api.Py
+"""Deployment utilities."""
+
+def deploy() -> None:
+    """Placeholder for deployment logic."""
+    print("Deploying API...")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from orchestrator import main_flow
+
+
+def test_flow_callable():
+    assert callable(main_flow)


### PR DESCRIPTION
## Summary
- add Prefect dependency
- create simple flow orchestrating ingestion, training and deployment tasks
- update pipeline entry point to run the flow
- document how to run the orchestrator
- add tests for orchestrator

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c8b2abfc832c88769976fb8d6b34