### PR TITLE
Document pipeline and restore workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,25 @@
+name: Docker Build
+on:
+  push:
+    branches: [ main ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/data-science-projects:latest
+          file: docker/Dockerfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          pip install -r requirements.txt
+      - name: Run flake8
+        run: flake8 src tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+on: [push, pull_request]
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Data Science Projects
+
+[![Lint](https://github.com/MediaJohnD/data-science-projects/actions/workflows/lint.yml/badge.svg)](https://github.com/MediaJohnD/data-science-projects/actions/workflows/lint.yml)
+[![Test](https://github.com/MediaJohnD/data-science-projects/actions/workflows/test.yml/badge.svg)](https://github.com/MediaJohnD/data-science-projects/actions/workflows/test.yml)
+[![Docker Build](https://github.com/MediaJohnD/data-science-projects/actions/workflows/docker-build.yml/badge.svg)](https://github.com/MediaJohnD/data-science-projects/actions/workflows/docker-build.yml)
+
+This repository is hosted at [https://github.com/MediaJohnD/data-science-projects](https://github.com/MediaJohnD/data-science-projects).
+
+## Local development
+
+Create a virtual environment and install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Run lint and tests:
+
+```bash
+flake8 src tests
+pytest -q
+```
+
+## Core Pipeline Steps
+
+1. **Ingestion** (`src/ingestion/load_data.py`)
+   - `load_csv(path)` loads raw CSV data into a DataFrame.
+2. **Feature Engineering** (`src/features/engineer_features.py`)
+   - `create_basic_features(df)` generates aggregate features.
+3. **Modeling** (`src/modeling/opti_shift.py`)
+   - `train_regressor(X, y)` trains an XGBoost model.
+4. **Scoring API** (`src/scoring/api.py`)
+   - A FastAPI application exposing a `/predict` endpoint.
+
+## Optional Utilities
+
+- **Monitoring** (`src/monitoring/log_metrics.py`)
+  - `log_metric(name, value)` prints simple metrics.
+- **Identity Resolution** (`src/resolution/identity_linker.py`)
+  - `link(df, key_columns)` removes duplicates.
+- **Contextual Triggers** (`src/contextual_triggers/trigger_engine.py`)
+  - `check_threshold(value, threshold)` evaluates thresholds.
+- **Clustering** (`src/modeling/clustering.py`)
+  - `cluster_kmeans(data, n_clusters)` performs KMeans clustering.
+- **Anomaly Detection** (`src/modeling/anomaly_detection.py`)
+  - `detect_anomalies(data)` trains an IsolationForest model.
+
+### Example: Clustering
+```python
+from src.modeling.clustering import cluster_kmeans
+import pandas as pd
+
+# ``df`` is a pandas DataFrame of numeric values
+model = cluster_kmeans(df, n_clusters=4)
+labels = model.labels_
+```
+
+### Example: Anomaly Detection
+```python
+from src.modeling.anomaly_detection import detect_anomalies
+import pandas as pd
+
+model = detect_anomalies(df, contamination=0.05)
+# Scores available via model.decision_function(df)
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,19 @@
-# Placeholder
+# Project Documentation
+
+## Orchestration
+
+This project uses **Prefect** to orchestrate the data ingestion, feature engineering and model training tasks.
+
+### Running the orchestrator
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Execute the flow using the pipeline entry point:
+   ```bash
+   python src/pipeline.py path/to/data.csv
+   ```
+
+The `main_flow` defined in `src/orchestrator.py` will load the dataset, engineer features, train a model and log a simple metric.
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,1 +1,18 @@
-# Placeholder
+# System Architecture
+
+This document outlines the overall architecture of the project.
+
+## Core Pipeline
+1. **Ingestion** - Load raw data using `load_csv`.
+2. **Feature Engineering** - Derive aggregates with `create_basic_features`.
+3. **Modeling** - Train models via `train_regressor`.
+4. **Scoring** - Serve predictions through the FastAPI app.
+
+## Optional Utilities
+- **Monitoring** - Basic metric logging with `log_metric`.
+- **Identity Resolution** - Deduplicate records using `link`.
+- **Contextual Triggers** - Evaluate thresholds via `check_threshold`.
+- **Clustering** - Cluster data points with `cluster_kmeans`.
+- **Anomaly Detection** - Train `detect_anomalies` for outlier detection.
+
+A high-level diagram is available in `configs/system_diagram.png`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ xgboost
 scikit-learn
 pandas
 numpy
+prefect

--- a/src/contextual_triggers/trigger_engine.py
+++ b/src/contextual_triggers/trigger_engine.py
@@ -1,1 +1,4 @@
-# Trigger Engine.Py
+
+def check_threshold(value: float, threshold: float) -> bool:
+    """Return True if value exceeds the threshold."""
+    return value > threshold

--- a/src/features/engineer_features.py
+++ b/src/features/engineer_features.py
@@ -1,1 +1,11 @@
-# Engineer Features.Py
+import pandas as pd
+
+
+def create_basic_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Add simple aggregated features."""
+    numeric_cols = df.select_dtypes(include="number")
+    df = df.copy()
+    if not numeric_cols.empty:
+        df["feature_sum"] = numeric_cols.sum(axis=1)
+        df["feature_mean"] = numeric_cols.mean(axis=1)
+    return df

--- a/src/ingestion/load_data.py
+++ b/src/ingestion/load_data.py
@@ -1,1 +1,6 @@
-# Load Data.Py
+import pandas as pd
+
+
+def load_csv(path: str) -> pd.DataFrame:
+    """Load a CSV file into a DataFrame."""
+    return pd.read_csv(path)

--- a/src/modeling/anomaly_detection.py
+++ b/src/modeling/anomaly_detection.py
@@ -1,0 +1,9 @@
+from sklearn.ensemble import IsolationForest
+import pandas as pd
+
+
+def detect_anomalies(data: pd.DataFrame, contamination: float = 0.1) -> IsolationForest:
+    """Train an IsolationForest model and return it."""
+    model = IsolationForest(contamination=contamination, random_state=0)
+    model.fit(data)
+    return model

--- a/src/modeling/clustering.py
+++ b/src/modeling/clustering.py
@@ -1,0 +1,9 @@
+from sklearn.cluster import KMeans
+import pandas as pd
+
+
+def cluster_kmeans(data: pd.DataFrame, n_clusters: int = 3) -> KMeans:
+    """Cluster observations using KMeans."""
+    model = KMeans(n_clusters=n_clusters, n_init=10)
+    model.fit(data)
+    return model

--- a/src/modeling/opti_shift.py
+++ b/src/modeling/opti_shift.py
@@ -1,1 +1,14 @@
-# Opti Shift.Py
+from xgboost import XGBRegressor
+import pandas as pd
+
+
+def train_regressor(X: pd.DataFrame, y: pd.Series) -> XGBRegressor:
+    """Train a simple XGBoost regressor."""
+    model = XGBRegressor(n_estimators=10, max_depth=3)
+    model.fit(X, y)
+    return model
+
+
+def predict(model: XGBRegressor, X: pd.DataFrame):
+    """Generate predictions using the trained model."""
+    return model.predict(X)

--- a/src/monitoring/log_metrics.py
+++ b/src/monitoring/log_metrics.py
@@ -1,1 +1,4 @@
-# Log Metrics.Py
+
+def log_metric(name: str, value: float) -> None:
+    """Log a metric to stdout."""
+    print(f"{name}: {value}")

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -1,0 +1,49 @@
+"""Simple Prefect orchestration for the data pipeline."""
+
+from prefect import flow, task
+
+from ingestion.load_data import load_csv
+from features.engineer_features import create_basic_features
+from modeling.opti_shift import train_regressor
+from monitoring.log_metrics import log_metric
+
+
+@task
+def ingest(path: str):
+    """Load the dataset from ``path``."""
+    return load_csv(path)
+
+
+@task
+def engineer(df):
+    """Generate features from the raw dataframe."""
+    return create_basic_features(df)
+
+
+@task
+def train(df):
+    """Train the regression model using the dataframe."""
+    target = df.columns[-1]
+    X = df.drop(columns=[target])
+    y = df[target]
+    model = train_regressor(X, y)
+    return model
+
+
+@task
+def deploy(model):
+    """Placeholder deployment step that logs model type."""
+    log_metric("model_type", type(model).__name__)
+
+
+@flow
+def main_flow(path: str) -> None:
+    """Orchestrate ingestion, training and deployment tasks."""
+    df = ingest(path)
+    df = engineer(df)
+    model = train(df)
+    deploy(model)
+
+
+if __name__ == "__main__":
+    main_flow("data.csv")

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,0 +1,9 @@
+"""Entry point for running the Prefect flow."""
+
+import sys
+from orchestrator import main_flow
+
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else "data.csv"
+    main_flow(path)

--- a/src/resolution/identity_linker.py
+++ b/src/resolution/identity_linker.py
@@ -1,1 +1,6 @@
-# Identity Linker.Py
+import pandas as pd
+
+
+def link(df: pd.DataFrame, key_columns: list) -> pd.DataFrame:
+    """Drop duplicate rows based on key columns."""
+    return df.drop_duplicates(subset=key_columns)

--- a/src/scoring/api.py
+++ b/src/scoring/api.py
@@ -1,1 +1,16 @@
-# Api.Py
+from fastapi import FastAPI
+from pydantic import BaseModel
+import pandas as pd
+
+app = FastAPI()
+
+
+class PredictionRequest(BaseModel):
+    data: list
+
+
+@app.post("/predict")
+async def predict_endpoint(payload: PredictionRequest):
+    df = pd.DataFrame(payload.data)
+    # Placeholder for model prediction
+    return {"rows": len(df)}

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import pandas as pd
+from orchestrator import main_flow
+
+
+def test_flow_runs(tmp_path):
+    df = pd.DataFrame({"x": [1, 2], "target": [1, 2]})
+    csv_path = tmp_path / "data.csv"
+    df.to_csv(csv_path, index=False)
+    # Execution should complete without raising exceptions
+    main_flow(str(csv_path))


### PR DESCRIPTION
## Summary
- reintroduce GitHub Actions workflows
- rebuild Prefect orchestrator and pipeline entry point
- update README with badges, local dev info, and pipeline examples
- document orchestrator usage in docs
- add test covering the flow

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684107134760832ca05b605d385c8a94