### PR TITLE
Add executed pipeline notebook and expand tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 This repository is hosted at [https://github.com/MediaJohnD/data-science-projects](https://github.com/MediaJohnD/data-science-projects).
 
+> **Note**
+> This project is still under active development and is **not** finalized for submission to the UT Austin or Georgia Tech data science programs.
+
 Clone the repository:
 
 ```bash
@@ -29,10 +32,12 @@ flake8 src tests
 pytest -q
 ```
 
-## OptiReveal Pipeline
+## Prefect Orchestration
 
-This project implements a small demonstration of the OptiReveal workflow. The
-pipeline is orchestrated with **Prefect** and consists of the following stages:
+This project implements a small demonstration of the OptiReveal workflow using
+**Prefect** for orchestration. A minimal sample data set is bundled with the
+code so that the full pipeline can be executed without external dependencies.
+The flow consists of the following stages:
 
 1. **Ingest** – load raw visit events.
 2. **Feature Engineering** – aggregate visits into device level features.
@@ -47,6 +52,19 @@ Run the end-to-end flow locally:
 ```bash
 python src/pipeline.py
 ```
+
+## 📓 Notebook Walkthrough
+
+An end-to-end example of the pipeline can be found in
+[`full_pipeline_summary.ipynb`](full_pipeline_summary.ipynb). Execute it with:
+
+```bash
+jupyter nbconvert --to notebook --execute full_pipeline_summary.ipynb --output executed.ipynb
+```
+
+The notebook uses a **small synthetic data set** included in the repository. In
+a production deployment you would replace this with a secure data loader for
+your real-world tables.
 
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,3 +13,14 @@ The OptiReveal prototype is organised as a series of Prefect tasks executed by
 The system is intentionally lightweight and suitable for demonstration
 purposes. It can be extended with richer data sources and additional modeling
 techniques.
+
+```text
+CSV -> Ingestion -> Feature Engineering -> Modeling
+            |                         |
+            +----> Monitoring <-------+
+                      |
+                   FastAPI
+```
+
+The `full_pipeline_summary.ipynb` notebook provides screenshots and notes for
+each step.

--- a/full_pipeline_summary.ipynb
+++ b/full_pipeline_summary.ipynb
@@ -1,0 +1,335 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a175a828",
+   "metadata": {},
+   "source": [
+    "# Full Pipeline Summary\n",
+    "\n",
+    "This notebook demonstrates the sample pipeline from ingestion to modeling. The repository uses small dummy data for illustration, which keeps the dependencies light for admissions review."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9af155e3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-06-20T01:06:49.208889Z",
+     "iopub.status.busy": "2025-06-20T01:06:49.208576Z",
+     "iopub.status.idle": "2025-06-20T01:06:50.232728Z",
+     "shell.execute_reply": "2025-06-20T01:06:50.231703Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>device_id</th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>poi_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>A</td>\n",
+       "      <td>2023-01-01 00:00:00</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>A</td>\n",
+       "      <td>2023-01-01 01:00:00</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>B</td>\n",
+       "      <td>2023-01-01 00:00:00</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>B</td>\n",
+       "      <td>2023-01-01 01:00:00</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>C</td>\n",
+       "      <td>2023-01-01 00:00:00</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  device_id           timestamp  poi_id\n",
+       "0         A 2023-01-01 00:00:00       1\n",
+       "1         A 2023-01-01 01:00:00       2\n",
+       "2         B 2023-01-01 00:00:00       1\n",
+       "3         B 2023-01-01 01:00:00       2\n",
+       "4         C 2023-01-01 00:00:00       1"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.path.append('src')\n",
+    "from ingestion.load_data import run as ingest\n",
+    "from features.engineer_features import run as engineer\n",
+    "from modeling.opti_shift import train\n",
+    "\n",
+    "# Load sample data\n",
+    "visits = ingest()\n",
+    "visits.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "754b2738",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-06-20T01:06:50.236171Z",
+     "iopub.status.busy": "2025-06-20T01:06:50.235741Z",
+     "iopub.status.idle": "2025-06-20T01:06:50.252485Z",
+     "shell.execute_reply": "2025-06-20T01:06:50.251592Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>device_id</th>\n",
+       "      <th>visit_count</th>\n",
+       "      <th>unique_pois</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>A</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>B</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>C</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>D</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>E</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>F</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>G</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>H</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>I</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>J</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>K</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>L</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   device_id  visit_count  unique_pois\n",
+       "0          A            2            2\n",
+       "1          B            2            2\n",
+       "2          C            2            2\n",
+       "3          D            2            2\n",
+       "4          E            2            2\n",
+       "5          F            2            2\n",
+       "6          G            2            2\n",
+       "7          H            2            2\n",
+       "8          I            2            2\n",
+       "9          J            2            1\n",
+       "10         K            2            1\n",
+       "11         L            2            1"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Engineer features\n",
+    "features = engineer(visits)\n",
+    "features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bf37d502",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-06-20T01:06:50.255462Z",
+     "iopub.status.busy": "2025-06-20T01:06:50.255193Z",
+     "iopub.status.idle": "2025-06-20T01:06:51.215460Z",
+     "shell.execute_reply": "2025-06-20T01:06:51.214371Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkAAAAHHCAYAAABXx+fLAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAQXZJREFUeJzt3XlYVdX+x/HPAWVQAQeQwUhRC9NEjK6EZeoVA0zS6pr6s1QyvZXc8lJaeEvUBps0G0zLVGwgtTItS9QwspI0BzK7amqSE+AMQgYJ+/dHD+d2AhTxwAH3+/U8+8mz9tprfxfHRz7tvfY5FsMwDAEAAJiIk6MLAAAAqG0EIAAAYDoEIAAAYDoEIAAAYDoEIAAAYDoEIAAAYDoEIAAAYDoEIAAAYDoEIAAAYDoEIKAeS05OlsViUVZW1gUdZ7FYNHny5BqpCfbVpk0bjRw5ssbGz8rKksViUXJyco2dA6iLCEBAHXLLLbeoUaNGOn36dKV9hg0bJhcXFx0/ftxu512/fr0mT56sU6dO2W1MR7rU5gPA/ghAQB0ybNgwnTlzRh999FGF+3/99VctX75c0dHRatGihe666y6dOXNGrVu3vqDznDlzRo899pj19fr16zVlypRLJjBcavOpSa1bt9aZM2d01113OboUoFYRgIA65JZbbpGHh4dSUlIq3L98+XIVFhZq2LBhkiRnZ2e5ubnJYrFc0Hnc3NzUoEGDi64XVVdaWqrffvvN0WWUY7FY5ObmJmdnZ0eXAtQqAhBQh7i7u+u2225TWlqajhw5Um5/SkqKPDw8dMstt0iqeA3Qpk2bFBUVJW9vb7m7uysoKEh33323zTh/XgM0efJkjR8/XpIUFBQki8VSpXVFGzZsUL9+/dSsWTM1btxYISEheumll2z6rF27Vj169FDjxo3VtGlTDRgwQDt27LDpM3LkSLVp06bc+JMnTy4X7CwWi+Lj47Vs2TJdffXVcnV1VadOnZSammpz3IXOp1evXrr66qu1efNmde/e3fpzmzNnTrm+RUVFSkpKUvv27eXq6qrAwEBNmDBBRUVFFdb67rvvqlOnTnJ1dbWp868Mw9CTTz6pyy67TI0aNVLv3r31448/Vtj31KlTGjdunAIDA+Xq6qr27dvr2WefVWlpqSTp999/V/PmzRUXF1fu2Pz8fLm5uenhhx+WVPkaoJ07d+qOO+6Qj4+P3N3dFRwcrP/85z82fQ4dOqS7775bvr6+1vdi/vz5lc4RqEv4X0Cgjhk2bJgWLlyoJUuWKD4+3tp+4sQJrVq1SkOHDpW7u3uFxx45ckQ33XSTfHx89Oijj6pp06bKysrS0qVLKz3fbbfdpp9++knvvfeeXnzxRXl7e0uSfHx8Kj1mzZo16t+/v/z9/fXggw/Kz89PO3bs0IoVK/Tggw9Kkj7//HPFxMSobdu2mjx5ss6cOaNXXnlF119/vbZs2VJh6KmKr7/+WkuXLtX9998vDw8Pvfzyy7r99tu1f/9+tWjRolrzkaSTJ0+qX79+uuOOOzR06FAtWbJE9913n1xcXKwBsrS0VLfccou+/vprjRkzRldddZV++OEHvfjii/rpp5+0bNkymzHXrl1rfR+9vb3POedJkybpySefVL9+/dSvXz9t2bJFN910k4qLi236/frrr+rZs6cOHTqkf/7zn7r88su1fv16JSYmKjs7WzNnzlTDhg116623aunSpXr99dfl4uJiPX7ZsmUqKirSkCFDKq1l27Zt6tGjhxo2bKgxY8aoTZs22rt3rz755BM99dRTkqTc3Fxdd9111qDn4+OjlStXatSoUcrPz9e4cePO+fMGHM4AUKecPXvW8Pf3NyIiImza58yZY0gyVq1aZW1bsGCBIcnYt2+fYRiG8dFHHxmSjO++++6c55BkJCUlWV8///zzNuOcr76goCCjdevWxsmTJ232lZaWWv8cGhpqtGzZ0jh+/Li17fvvvzecnJyM4cOHW9tGjBhhtG7dutx5kpKSjL/+EyXJcHFxMfbs2WMzpiTjlVdeqdZ8DMMwevbsaUgypk+fbm0rKiqyzqG4uNgwDMN4++23DScnJ+Orr76yOb7svfnmm29sanVycjJ+/PHH857/yJEjhouLi3HzzTfb/AwnTpxoSDJGjBhhbXviiSeMxo0bGz/99JPNGI8++qjh7Oxs7N+/3zAMw1i1apUhyfjkk09s+vXr189o27at9fW+ffsMScaCBQusbTfeeKPh4eFh/PLLLzbH/rm2UaNGGf7+/saxY8ds+gwZMsTw8vIyfv311/POG3AkboEBdYyzs7OGDBmijIwMm9s2KSkp8vX1VZ8+fSo9tmnTppKkFStW6Pfff6+R+rZu3ap9+/Zp3Lhx1vOVKbtllZ2drczMTI0cOVLNmze37g8JCVHfvn312WefVfv8kZGRateunc2Ynp6e+vnnn6s9piQ1aNBA//znP62vXVxc9M9//lNHjhzR5s2bJUnvv/++rrrqKnXo0EHHjh2zbn//+98lSV988YXNmD179lTHjh3Pe+7PP/9cxcXF+te//mVz26+iqyjvv/++evTooWbNmtnUEBkZqZKSEq1bt06S9Pe//13e3t5avHix9diTJ09qzZo1Gjx4cKW1HD16VOvWrdPdd9+tyy+/3GZfWW2GYejDDz9UbGysDMOwqSMqKkp5eXnasmXLeecNOBIBCKiDyhY5ly2GPnjwoL766isNGTLknItVe/bsqdtvv11TpkyRt7e3BgwYoAULFpRbn3Ix9u7dK0m6+uqrK+3zyy+/SJKCg4PL7bvqqqt07NgxFRYWVuv8f/2lLEnNmjXTyZMnqzVemYCAADVu3Nim7corr5QkaxDdvXu3fvzxR/n4+NhsZf3+um4rKCioSucu+3ldccUVNu0+Pj5q1qyZTdvu3buVmpparobIyEibGho0aKDbb79dy5cvt77/S5cu1e+//37OAFQWJM/1/h49elSnTp3SG2+8Ua6OsnVHFa1hA+oS1gABdVBYWJg6dOig9957TxMnTtR7770nwzCswagyFotFH3zwgb799lt98sknWrVqle6++25Nnz5d3377rZo0aVJLM6i6yp5gKykpqbC9sgBoGIbdaqpMaWmpOnfurBkzZlS4PzAw0OZ1ZWu1LraGvn37asKECRXuLwtjkjRkyBC9/vrrWrlypQYOHKglS5aoQ4cO6tKly0XXIEl33nmnRowYUWGfkJCQizoHUNMIQEAdNWzYMD3++OPatm2bUlJSdMUVV+hvf/tblY697rrrdN111+mpp55SSkqKhg0bpkWLFumee+6psP+FPEZfdvtp+/bt1qsOf1X2uUS7du0qt2/nzp3y9va2Xm1p1qxZhZ/XU3ZVpDou9GMBJOnw4cMqLCy0uQr0008/SZJ18XK7du30/fffq0+fPtU6R2XKfl67d+9W27Ztre1Hjx4td2WrXbt2KigoqPRn/2c33nij/P39tXjxYt1www1au3ZtuSe5/qrs/Nu3b6+0j4+Pjzw8PFRSUlKlOoC6iFtgQB1VdrVn0qRJyszMPO/VH+mPNR5/vRISGhoqSee8DVb2S78qHxx4zTXXKCgoSDNnzizXv+zc/v7+Cg0N1cKFC236bN++XatXr1a/fv2sbe3atVNeXp62bdtmbcvOzq70wyCr4kLmU+bs2bN6/fXXra+Li4v1+uuvy8fHR2FhYZKkO+64Q4cOHdLcuXPLHX/mzJlq39aLjIxUw4YN9corr9i8fzNnzizX94477lBGRoZWrVpVbt+pU6d09uxZ62snJyf94x//0CeffKK3335bZ8+ePeftL+mPcHPjjTdq/vz52r9/v82+stqcnZ11++2368MPP6wwKB09evSc5wDqAq4AAXVUUFCQunfvruXLl0tSlQLQwoUL9dprr+nWW29Vu3btdPr0ac2dO1eenp42oeOvyn7B/+c//9GQIUPUsGFDxcbGllsTI/3xS3X27NmKjY1VaGio4uLi5O/vr507d+rHH3+0/mJ+/vnnFRMTo4iICI0aNcr6GLyXl5fN95ANGTJEjzzyiG699VY98MAD+vXXXzV79mxdeeWV1V5IeyHzKRMQEKBnn31WWVlZuvLKK7V48WJlZmbqjTfeUMOGDSVJd911l5YsWaJ7771XX3zxha6//nqVlJRo586dWrJkiVatWqVrr732guv18fHRww8/rGnTpql///7q16+ftm7dqpUrV1of4y8zfvx4ffzxx+rfv79GjhypsLAwFRYW6ocfftAHH3ygrKwsm2MGDx6sV155RUlJSercubOuuuqq89bz8ssv64YbbtA111yjMWPGKCgoSFlZWfr000+VmZkpSXrmmWf0xRdfKDw8XKNHj1bHjh114sQJbdmyRZ9//rlOnDhxwT8HoFY57gE0AOcza9YsQ5LRrVu3Cvf/9TH4LVu2GEOHDjUuv/xyw9XV1WjZsqXRv39/Y9OmTTbH6S+PwRvGH49Xt2rVynBycqrSI+Rff/210bdvX8PDw8No3LixERISYvMoumEYxueff25cf/31hru7u+Hp6WnExsYa//3vf8uNtXr1auPqq682XFxcjODgYOOdd96p9DH4sWPHlju+devWNo+KX+h8evbsaXTq1MnYtGmTERERYbi5uRmtW7c2Xn311XJ9i4uLjWeffdbo1KmT4erqajRr1swICwszpkyZYuTl5Z231sqUlJQYU6ZMMfz9/Q13d3ejV69exvbt2yuc2+nTp43ExESjffv2houLi+Ht7W10797deOGFF6yP7JcpLS01AgMDDUnGk08+We68FT0GbxiGsX37duPWW281mjZtari5uRnBwcHG448/btMnNzfXGDt2rBEYGGg0bNjQ8PPzM/r06WO88cYbVZ434CgWw6iFlYMAUIf16tVLx44dO+e6FwCXFtYAAQAA0yEAAQAA0yEAAQAA02ENEAAAMB2uAAEAANMhAAEAANPhgxArUFpaqsOHD8vDw8OuH3cPAABqjmEYOn36tAICAuTkdO5rPASgChw+fLjclxoCAID64cCBA7rsssvO2YcAVAEPDw9Jf/wAPT09HVwNAACoivz8fAUGBlp/j58LAagCZbe9PD09CUAAANQzVVm+wiJoAABgOgQgAABgOgQgAABgOgQgAABgOgQgAABgOgQgAABgOgQgAABgOgQgAABgOgQgAABgOgQgAABgOg4NQNOmTdPf/vY3eXh4qGXLlho4cKB27dp13uPef/99dejQQW5uburcubM+++wzm/2GYWjSpEny9/eXu7u7IiMjtXv37pqaBgAAqGccGoC+/PJLjR07Vt9++63WrFmj33//XTfddJMKCwsrPWb9+vUaOnSoRo0apa1bt2rgwIEaOHCgtm/fbu3z3HPP6eWXX9acOXO0YcMGNW7cWFFRUfrtt99qY1oAAKCOsxiGYTi6iDJHjx5Vy5Yt9eWXX+rGG2+ssM/gwYNVWFioFStWWNuuu+46hYaGas6cOTIMQwEBAXrooYf08MMPS5Ly8vLk6+ur5ORkDRky5Lx15Ofny8vLS3l5eXwZKgAA9cSF/P6uU2uA8vLyJEnNmzevtE9GRoYiIyNt2qKiopSRkSFJ2rdvn3Jycmz6eHl5KTw83NoHAACYWwNHF1CmtLRU48aN0/XXX6+rr7660n45OTny9fW1afP19VVOTo51f1lbZX3+qqioSEVFRdbX+fn51ZoDAACoH+pMABo7dqy2b9+ur7/+utbPPW3aNE2ZMuWcfcLGv1VL1VRu8/PDz9unPtRJjVXD+20/l0KNUv2okxqrhvfbfqrys6xInbgFFh8frxUrVuiLL77QZZddds6+fn5+ys3NtWnLzc2Vn5+fdX9ZW2V9/ioxMVF5eXnW7cCBA9WdCgAAqAccGoAMw1B8fLw++ugjrV27VkFBQec9JiIiQmlpaTZta9asUUREhCQpKChIfn5+Nn3y8/O1YcMGa5+/cnV1laenp80GAAAuXQ69BTZ27FilpKRo+fLl8vDwsK7R8fLykru7uyRp+PDhatWqlaZNmyZJevDBB9WzZ09Nnz5dN998sxYtWqRNmzbpjTfekCRZLBaNGzdOTz75pK644goFBQXp8ccfV0BAgAYOHOiQeQIAgLrFoQFo9uzZkqRevXrZtC9YsEAjR46UJO3fv19OTv+7UNW9e3elpKToscce08SJE3XFFVdo2bJlNgunJ0yYoMLCQo0ZM0anTp3SDTfcoNTUVLm5udX4nAAAQN3n0ABUlY8gSk9PL9c2aNAgDRo0qNJjLBaLpk6dqqlTp15MeQAA4BJVJxZBAwAA1CYCEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB0CEAAAMB2HBqB169YpNjZWAQEBslgsWrZs2Tn7jxw5UhaLpdzWqVMna5/JkyeX29+hQ4cangkAAKhPHBqACgsL1aVLF82aNatK/V966SVlZ2dbtwMHDqh58+YaNGiQTb9OnTrZ9Pv6669ronwAAFBPNXDkyWNiYhQTE1Pl/l5eXvLy8rK+XrZsmU6ePKm4uDibfg0aNJCfn5/d6gQAAJeWer0GaN68eYqMjFTr1q1t2nfv3q2AgAC1bdtWw4YN0/79+x1UIQAAqIscegXoYhw+fFgrV65USkqKTXt4eLiSk5MVHBys7OxsTZkyRT169ND27dvl4eFR4VhFRUUqKiqyvs7Pz6/R2gEAgGPV2wC0cOFCNW3aVAMHDrRp//MttZCQEIWHh6t169ZasmSJRo0aVeFY06ZN05QpU2qyXAAAUIfUy1tghmFo/vz5uuuuu+Ti4nLOvk2bNtWVV16pPXv2VNonMTFReXl51u3AgQP2LhkAANQh9TIAffnll9qzZ0+lV3T+rKCgQHv37pW/v3+lfVxdXeXp6WmzAQCAS5dDA1BBQYEyMzOVmZkpSdq3b58yMzOti5YTExM1fPjwcsfNmzdP4eHhuvrqq8vte/jhh/Xll18qKytL69ev16233ipnZ2cNHTq0RucCAADqD4euAdq0aZN69+5tfZ2QkCBJGjFihJKTk5WdnV3uCa68vDx9+OGHeumllyoc8+DBgxo6dKiOHz8uHx8f3XDDDfr222/l4+NTcxMBAAD1ikMDUK9evWQYRqX7k5OTy7V5eXnp119/rfSYRYsW2aM0AABwCauXa4AAAAAuBgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYDgEIAACYjkMD0Lp16xQbG6uAgABZLBYtW7bsnP3T09NlsVjKbTk5OTb9Zs2apTZt2sjNzU3h4eHauHFjDc4CAADUNw4NQIWFherSpYtmzZp1Qcft2rVL2dnZ1q1ly5bWfYsXL1ZCQoKSkpK0ZcsWdenSRVFRUTpy5Ii9ywcAAPVUA0eePCYmRjExMRd8XMuWLdW0adMK982YMUOjR49WXFycJGnOnDn69NNPNX/+fD366KMXUy4AALhE1Ms1QKGhofL391ffvn31zTffWNuLi4u1efNmRUZGWtucnJwUGRmpjIwMR5QKAADqoHoVgPz9/TVnzhx9+OGH+vDDDxUYGKhevXppy5YtkqRjx46ppKREvr6+Nsf5+vqWWyf0Z0VFRcrPz7fZAADApcuht8AuVHBwsIKDg62vu3fvrr179+rFF1/U22+/Xe1xp02bpilTptijRAAAUA/UqytAFenWrZv27NkjSfL29pazs7Nyc3Nt+uTm5srPz6/SMRITE5WXl2fdDhw4UKM1AwAAx6r3ASgzM1P+/v6SJBcXF4WFhSktLc26v7S0VGlpaYqIiKh0DFdXV3l6etpsAADg0uXQW2AFBQXWqzeStG/fPmVmZqp58+a6/PLLlZiYqEOHDumtt96SJM2cOVNBQUHq1KmTfvvtN7355ptau3atVq9ebR0jISFBI0aM0LXXXqtu3bpp5syZKiwstD4VBgAA4NAAtGnTJvXu3dv6OiEhQZI0YsQIJScnKzs7W/v377fuLy4u1kMPPaRDhw6pUaNGCgkJ0eeff24zxuDBg3X06FFNmjRJOTk5Cg0NVWpqarmF0QAAwLwcGoB69eolwzAq3Z+cnGzzesKECZowYcJ5x42Pj1d8fPzFlgcAAC5R9X4NEAAAwIUiAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANMhAAEAANNxaABat26dYmNjFRAQIIvFomXLlp2z/9KlS9W3b1/5+PjI09NTERERWrVqlU2fyZMny2Kx2GwdOnSowVkAAID6xqEBqLCwUF26dNGsWbOq1H/dunXq27evPvvsM23evFm9e/dWbGystm7datOvU6dOys7Otm5ff/11TZQPAADqqQaOPHlMTIxiYmKq3H/mzJk2r59++mktX75cn3zyibp27Wptb9Cggfz8/OxVJgAAuMTU6zVApaWlOn36tJo3b27Tvnv3bgUEBKht27YaNmyY9u/f76AKAQBAXeTQK0AX64UXXlBBQYHuuOMOa1t4eLiSk5MVHBys7OxsTZkyRT169ND27dvl4eFR4ThFRUUqKiqyvs7Pz6/x2gEAgONU6wrQW2+9ZRMYyhQXF+utt9666KKqIiUlRVOmTNGSJUvUsmVLa3tMTIwGDRqkkJAQRUVF6bPPPtOpU6e0ZMmSSseaNm2avLy8rFtgYGBtTAEAADhItQJQXFyc8vLyyrWfPn1acXFxF13U+SxatEj33HOPlixZosjIyHP2bdq0qa688krt2bOn0j6JiYnKy8uzbgcOHLB3yQAAoA6pVgAyDEMWi6Vc+8GDB+Xl5XXRRZ3Le++9p7i4OL333nu6+eabz9u/oKBAe/fulb+/f6V9XF1d5enpabMBAIBL1wWtAeratav1s3X69OmjBg3+d3hJSYn27dun6OjoKo9XUFBgc2Vm3759yszMVPPmzXX55ZcrMTFRhw4dst5WS0lJ0YgRI/TSSy8pPDxcOTk5kiR3d3dr8Hr44YcVGxur1q1b6/Dhw0pKSpKzs7OGDh16IVMFAACXsAsKQAMHDpQkZWZmKioqSk2aNLHuc3FxUZs2bXT77bdXebxNmzapd+/e1tcJCQmSpBEjRig5OVnZ2dk2T3C98cYbOnv2rMaOHauxY8da28v6S39chRo6dKiOHz8uHx8f3XDDDfr222/l4+NzIVMFAACXsAsKQElJSZKkNm3aaPDgwXJzc7uok/fq1UuGYVS6vyzUlElPTz/vmIsWLbqomgAAwKWvWo/BjxgxQtIfT30dOXJEpaWlNvsvv/zyi68MAACghlQrAO3evVt333231q9fb9Netji6pKTELsUBAADUhGoFoJEjR6pBgwZasWKF/P39K3wiDAAAoK6qVgDKzMzU5s2b+ZZ1AABQL1Xrc4A6duyoY8eO2bsWAACAWlGtAPTss89qwoQJSk9P1/Hjx5Wfn2+zAQAA1GXVugVW9vUTffr0sWlnETQAAKgPqhWAvvjiC3vXAQAAUGuqFYB69uxp7zoAAABqTbUC0Lp16865/8Ybb6xWMQAAALWhWgGoV69e5dr+/FlArAECAAB1WbWeAjt58qTNduTIEaWmpupvf/ubVq9ebe8aAQAA7KpaV4C8vLzKtfXt21cuLi5KSEjQ5s2bL7owAACAmlKtK0CV8fX11a5du+w5JAAAgN1V6wrQtm3bbF4bhqHs7Gw988wzCg0NtUddAAAANaZaASg0NFQWi0WGYdi0X3fddZo/f75dCgMAAKgp1QpA+/bts3nt5OQkHx8fubm52aUoAACAmlStANS6dWt71wEAAFBrqr0I+ssvv1RsbKzat2+v9u3b65ZbbtFXX31lz9oAAABqRLUC0DvvvKPIyEg1atRIDzzwgB544AG5u7urT58+SklJsXeNAAAAdlWtW2BPPfWUnnvuOf373/+2tj3wwAOaMWOGnnjiCf3f//2f3QoEAACwt2pdAfr5558VGxtbrv2WW24pt0AaAACgrqlWAAoMDFRaWlq59s8//1yBgYEXXRQAAEBNqtYtsIceekgPPPCAMjMz1b17d0nSN998o+TkZL300kt2LRAAAMDeqhWA7rvvPvn5+Wn69OlasmSJJOmqq67S4sWLNWDAALsWCAAAYG/VCkCSdOutt+rWW2+1Zy0AAAC1olprgL777jtt2LChXPuGDRu0adOmiy4KAACgJlUrAI0dO1YHDhwo137o0CGNHTv2oosCAACoSdUKQP/97391zTXXlGvv2rWr/vvf/150UQAAADWpWgHI1dVVubm55dqzs7PVoEG1lxUBAADUimoFoJtuukmJiYnKy8uztp06dUoTJ05U37597VYcAABATajW5ZoXXnhBN954o1q3bq2uXbtKkjIzM+Xr66u3337brgUCAADYW7UCUKtWrbRt2za9++67+v777+Xu7q64uDgNHTpUDRs2tHeNAAAAdlWtW2CS1LhxY40ZM0azZs3SCy+8oOHDh5cLPzfffLOys7MrHWPdunWKjY1VQECALBaLli1bdt7zpqen65prrpGrq6vat2+v5OTkcn1mzZqlNm3ayM3NTeHh4dq4ceOFTg8AAFzCqh2AqmLdunU6c+ZMpfsLCwvVpUsXzZo1q0rj7du3TzfffLN69+6tzMxMjRs3Tvfcc49WrVpl7bN48WIlJCQoKSlJW7ZsUZcuXRQVFaUjR45c9HwAAMClwaGPbMXExCgmJqbK/efMmaOgoCBNnz5d0h9fv/H111/rxRdfVFRUlCRpxowZGj16tOLi4qzHfPrpp5o/f74effRR+08CAADUOzV6BcjeMjIyFBkZadMWFRWljIwMSVJxcbE2b95s08fJyUmRkZHWPgAAAPXqQ3tycnLk6+tr0+br66v8/HydOXNGJ0+eVElJSYV9du7cWem4RUVFKioqsr7Oz8+3b+EAAKBOqVdXgGrKtGnT5OXlZd0CAwMdXRIAAKhB9SoA+fn5lfsE6tzcXHl6esrd3V3e3t5ydnausI+fn1+l45Z9qGPZVtH3nAEAgEtHtQLQunXrdPbs2XLtZ8+e1bp166yvJ06cqObNm1e/ur+IiIhQWlqaTduaNWsUEREhSXJxcVFYWJhNn9LSUqWlpVn7VMTV1VWenp42GwAAuHRVKwD17t1bJ06cKNeel5en3r17W18nJiaqadOmlY5TUFCgzMxMZWZmSvrjMffMzEzt37/fevzw4cOt/e+99179/PPPmjBhgnbu3KnXXntNS5Ys0b///W9rn4SEBM2dO1cLFy7Ujh07dN9996mwsND6VBgAAEC1FkEbhiGLxVKu/fjx42rcuHGVx9m0aZNNYEpISJAkjRgxQsnJycrOzraGIUkKCgrSp59+qn//+9966aWXdNlll+nNN9+0PgIvSYMHD9bRo0c1adIk5eTkKDQ0VKmpqeUWRgMAAPO6oAB02223SZIsFotGjhwpV1dX676SkhJt27ZN3bt3r/J4vXr1kmEYle6v6FOee/Xqpa1bt55z3Pj4eMXHx1e5DgAAYC4XFIC8vLwk/XEFyMPDQ+7u7tZ9Li4uuu666zR69Gj7VggAAGBnFxSAFixYIElq06aNHn744Qu63QUAAFBXVGsNUFJSkr3rAAAAqDVVDkDXXHON0tLS1KxZM3Xt2rXCRdBltmzZYpfiAAAAakKVA9CAAQOsi54HDhxYU/UAAADUuCoHoD/f9uIWGAAAqM+q9UGIBw4c0MGDB62vN27cqHHjxumNN96wW2EAAAA1pVoB6P/+7//0xRdfSPrjG9ojIyO1ceNG/ec//9HUqVPtWiAAAIC9VSsAbd++Xd26dZMkLVmyRJ07d9b69ev17rvvVvjhhQAAAHVJtQLQ77//bl0Q/fnnn+uWW26RJHXo0EHZ2dn2qw4AAKAGVCsAderUSXPmzNFXX32lNWvWKDo6WpJ0+PBhtWjRwq4FAgAA2Fu1AtCzzz6r119/Xb169dLQoUPVpUsXSdLHH39svTUGAABQV1Xrk6B79eqlY8eOKT8/X82aNbO2jxkzRo0aNbJbcQAAADWhWgFIkpydnW3Cj/THd4QBAADUdXwVBgAAMB2+CgMAAJhOtb4K48CBAxo2bJh69+5dI0UBAADUpGo9BXb06FHFxMQoMDBQEyZM0Pfff2/vugAAAGpMtQLQ8uXLlZ2drccff1wbN27UNddco06dOunpp59WVlaWnUsEAACwr2oFIElq1qyZxowZo/T0dP3yyy8aOXKk3n77bbVv396e9QEAANhdtQNQmd9//12bNm3Shg0blJWVJV9fX3vUBQAAUGOqHYC++OILjR49Wr6+vho5cqQ8PT21YsUKHTx40J71AQAA2F21PgixVatWOnHihKKjo/XGG28oNjbW+og8AABAXVetADR58mQNGjRITZs2tXM5AAAANa9aAWj06NH2rgMAAKDWXPQiaAAAgPqGAAQAAEyHAAQAAEyHAAQAAEyHAAQAAEyHAAQAAEyHAAQAAEyHAAQAAEynTgSgWbNmqU2bNnJzc1N4eLg2btxYad9evXrJYrGU226++WZrn5EjR5bbHx0dXRtTAQAA9UC1PgnanhYvXqyEhATNmTNH4eHhmjlzpqKiorRr1y61bNmyXP+lS5equLjY+vr48ePq0qWLBg0aZNMvOjpaCxYssL7mu8oAAEAZh18BmjFjhkaPHq24uDh17NhRc+bMUaNGjTR//vwK+zdv3lx+fn7Wbc2aNWrUqFG5AOTq6mrTr1mzZrUxHQAAUA84NAAVFxdr8+bNioyMtLY5OTkpMjJSGRkZVRpj3rx5GjJkiBo3bmzTnp6erpYtWyo4OFj33Xefjh8/btfaAQBA/eXQW2DHjh1TSUmJfH19bdp9fX21c+fO8x6/ceNGbd++XfPmzbNpj46O1m233aagoCDt3btXEydOVExMjDIyMuTs7FxunKKiIhUVFVlf5+fnV3NGAACgPnD4GqCLMW/ePHXu3FndunWzaR8yZIj1z507d1ZISIjatWun9PR09enTp9w406ZN05QpU2q8XgAAUDc49BaYt7e3nJ2dlZuba9Oem5srPz+/cx5bWFioRYsWadSoUec9T9u2beXt7a09e/ZUuD8xMVF5eXnW7cCBA1WfBAAAqHccGoBcXFwUFhamtLQ0a1tpaanS0tIUERFxzmPff/99FRUV6c477zzveQ4ePKjjx4/L39+/wv2urq7y9PS02QAAwKXL4U+BJSQkaO7cuVq4cKF27Nih++67T4WFhYqLi5MkDR8+XImJieWOmzdvngYOHKgWLVrYtBcUFGj8+PH69ttvlZWVpbS0NA0YMEDt27dXVFRUrcwJAADUbQ5fAzR48GAdPXpUkyZNUk5OjkJDQ5WammpdGL1//345OdnmtF27dunrr7/W6tWry43n7Oysbdu2aeHChTp16pQCAgJ000036YknnuCzgAAAgKQ6EIAkKT4+XvHx8RXuS09PL9cWHBwswzAq7O/u7q5Vq1bZszwAAHCJcfgtMAAAgNpGAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZDAAIAAKZTJwLQrFmz1KZNG7m5uSk8PFwbN26stG9ycrIsFovN5ubmZtPHMAxNmjRJ/v7+cnd3V2RkpHbv3l3T0wAAAPWEwwPQ4sWLlZCQoKSkJG3ZskVdunRRVFSUjhw5Uukxnp6eys7Otm6//PKLzf7nnntOL7/8subMmaMNGzaocePGioqK0m+//VbT0wEAAPWAwwPQjBkzNHr0aMXFxaljx46aM2eOGjVqpPnz51d6jMVikZ+fn3Xz9fW17jMMQzNnztRjjz2mAQMGKCQkRG+99ZYOHz6sZcuW1cKMAABAXefQAFRcXKzNmzcrMjLS2ubk5KTIyEhlZGRUelxBQYFat26twMBADRgwQD/++KN13759+5STk2MzppeXl8LDw885JgAAMA+HBqBjx46ppKTE5gqOJPn6+ionJ6fCY4KDgzV//nwtX75c77zzjkpLS9W9e3cdPHhQkqzHXciYRUVFys/Pt9kAAMCly+G3wC5URESEhg8frtDQUPXs2VNLly6Vj4+PXn/99WqPOW3aNHl5eVm3wMBAO1YMAADqGocGIG9vbzk7Oys3N9emPTc3V35+flUao2HDhuratav27NkjSdbjLmTMxMRE5eXlWbcDBw5c6FQAAEA94tAA5OLiorCwMKWlpVnbSktLlZaWpoiIiCqNUVJSoh9++EH+/v6SpKCgIPn5+dmMmZ+frw0bNlQ6pqurqzw9PW02AABw6Wrg6AISEhI0YsQIXXvtterWrZtmzpypwsJCxcXFSZKGDx+uVq1aadq0aZKkqVOn6rrrrlP79u116tQpPf/88/rll190zz33SPrjCbFx48bpySef1BVXXKGgoCA9/vjjCggI0MCBAx01TQAAUIc4PAANHjxYR48e1aRJk5STk6PQ0FClpqZaFzHv379fTk7/u1B18uRJjR49Wjk5OWrWrJnCwsK0fv16dezY0dpnwoQJKiws1JgxY3Tq1CndcMMNSk1NLfeBiQAAwJwcHoAkKT4+XvHx8RXuS09Pt3n94osv6sUXXzzneBaLRVOnTtXUqVPtVSIAALiE1LunwAAAAC4WAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJgOAQgAAJhOnQhAs2bNUps2beTm5qbw8HBt3Lix0r5z585Vjx491KxZMzVr1kyRkZHl+o8cOVIWi8Vmi46OrulpAACAesLhAWjx4sVKSEhQUlKStmzZoi5duigqKkpHjhypsH96erqGDh2qL774QhkZGQoMDNRNN92kQ4cO2fSLjo5Wdna2dXvvvfdqYzoAAKAecHgAmjFjhkaPHq24uDh17NhRc+bMUaNGjTR//vwK+7/77ru6//77FRoaqg4dOujNN99UaWmp0tLSbPq5urrKz8/PujVr1qw2pgMAAOoBhwag4uJibd68WZGRkdY2JycnRUZGKiMjo0pj/Prrr/r999/VvHlzm/b09HS1bNlSwcHBuu+++3T8+HG71g4AAOqvBo48+bFjx1RSUiJfX1+bdl9fX+3cubNKYzzyyCMKCAiwCVHR0dG67bbbFBQUpL1792rixImKiYlRRkaGnJ2dy41RVFSkoqIi6+v8/PxqzggAANQHDg1AF+uZZ57RokWLlJ6eLjc3N2v7kCFDrH/u3LmzQkJC1K5dO6Wnp6tPnz7lxpk2bZqmTJlSKzUDAADHc+gtMG9vbzk7Oys3N9emPTc3V35+fuc89oUXXtAzzzyj1atXKyQk5Jx927ZtK29vb+3Zs6fC/YmJicrLy7NuBw4cuLCJAACAesWhAcjFxUVhYWE2C5jLFjRHRERUetxzzz2nJ554Qqmpqbr22mvPe56DBw/q+PHj8vf3r3C/q6urPD09bTYAAHDpcvhTYAkJCZo7d64WLlyoHTt26L777lNhYaHi4uIkScOHD1diYqK1/7PPPqvHH39c8+fPV5s2bZSTk6OcnBwVFBRIkgoKCjR+/Hh9++23ysrKUlpamgYMGKD27dsrKirKIXMEAAB1i8PXAA0ePFhHjx7VpEmTlJOTo9DQUKWmploXRu/fv19OTv/LabNnz1ZxcbH+8Y9/2IyTlJSkyZMny9nZWdu2bdPChQt16tQpBQQE6KabbtITTzwhV1fXWp0bAAComxwegCQpPj5e8fHxFe5LT0+3eZ2VlXXOsdzd3bVq1So7VQYAAC5FDr8FBgAAUNsIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHQIQAAAwHTqRACaNWuW2rRpIzc3N4WHh2vjxo3n7P/++++rQ4cOcnNzU+fOnfXZZ5/Z7DcMQ5MmTZK/v7/c3d0VGRmp3bt31+QUAABAPeLwALR48WIlJCQoKSlJW7ZsUZcuXRQVFaUjR45U2H/9+vUaOnSoRo0apa1bt2rgwIEaOHCgtm/fbu3z3HPP6eWXX9acOXO0YcMGNW7cWFFRUfrtt99qa1oAAKAOc3gAmjFjhkaPHq24uDh17NhRc+bMUaNGjTR//vwK+7/00kuKjo7W+PHjddVVV+mJJ57QNddco1dffVXSH1d/Zs6cqccee0wDBgxQSEiI3nrrLR0+fFjLli2rxZkBAIC6yqEBqLi4WJs3b1ZkZKS1zcnJSZGRkcrIyKjwmIyMDJv+khQVFWXtv2/fPuXk5Nj08fLyUnh4eKVjAgAAc2ngyJMfO3ZMJSUl8vX1tWn39fXVzp07KzwmJyenwv45OTnW/WVtlfX5q6KiIhUVFVlf5+XlSZLy8/OtbSVFZ6oypRr153oqUx/qpMaq4f22n0uhRql+1EmNVcP7bT9/rrHsz4ZhnP9Aw4EOHTpkSDLWr19v0z5+/HijW7duFR7TsGFDIyUlxaZt1qxZRsuWLQ3DMIxvvvnGkGQcPnzYps+gQYOMO+64o8Ixk5KSDElsbGxsbGxsl8B24MCB82YQh14B8vb2lrOzs3Jzc23ac3Nz5efnV+Exfn5+5+xf9t/c3Fz5+/vb9AkNDa1wzMTERCUkJFhfl5aW6sSJE2rRooUsFssFz6si+fn5CgwM1IEDB+Tp6WmXMe2tPtQo1Y86qdF+6kOd1Gg/9aFOarQfe9dpGIZOnz6tgICA8/Z1aABycXFRWFiY0tLSNHDgQEl/hI+0tDTFx8dXeExERITS0tI0btw4a9uaNWsUEREhSQoKCpKfn5/S0tKsgSc/P18bNmzQfffdV+GYrq6ucnV1tWlr2rTpRc2tMp6ennX6L6NUP2qU6ked1Gg/9aFOarSf+lAnNdqPPev08vKqUj+HBiBJSkhI0IgRI3TttdeqW7dumjlzpgoLCxUXFydJGj58uFq1aqVp06ZJkh588EH17NlT06dP180336xFixZp06ZNeuONNyRJFotF48aN05NPPqkrrrhCQUFBevzxxxUQEGANWQAAwNwcHoAGDx6so0ePatKkScrJyVFoaKhSU1Oti5j3798vJ6f/PazWvXt3paSk6LHHHtPEiRN1xRVXaNmyZbr66qutfSZMmKDCwkKNGTNGp06d0g033KDU1FS5ubnV+vwAAEDd4/AAJEnx8fGV3vJKT08v1zZo0CANGjSo0vEsFoumTp2qqVOn2qvEi+bq6qqkpKRyt9rqkvpQo1Q/6qRG+6kPdVKj/dSHOqnRfhxZp8UwqvKsGAAAwKXD4Z8EDQAAUNsIQAAAwHQIQAAAwHQIQAAAwHQIQLUgIyNDzs7Ouvnmmx1dSoVGjhwpi8Vi3Vq0aKHo6Ght27bN0aXZyMnJ0b/+9S+1bdtWrq6uCgwMVGxsrNLS0hxdmiTbn2PDhg3l6+urvn37av78+SotLXV0eVZ/fb/LtujoaEeXZqOyOvfs2ePo0qxycnL04IMPqn379nJzc5Ovr6+uv/56zZ49W7/++qujy9PIkSMr/Pyz9PR0WSwWnTp1qtZrOp/Kaq5L6nKNFdX2wQcfyM3NTdOnT3dMURWoCz9DAlAtmDdvnv71r39p3bp1Onz4sKPLqVB0dLSys7OVnZ2ttLQ0NWjQQP3793d0WVZZWVkKCwvT2rVr9fzzz+uHH35QamqqevfurbFjxzq6PKuyn2NWVpZWrlyp3r1768EHH1T//v119uxZR5dn9ef3u2x77733HF1WORXVGRQU5OiyJEk///yzunbtqtWrV+vpp5/W1q1blZGRoQkTJmjFihX6/PPPHV0ioDfffFPDhg3T7Nmz9dBDDzm6nDqlTnwO0KWsoKBAixcv1qZNm5STk6Pk5GRNnDjR0WWV4+rqavN9ao8++qh69Oiho0ePysfHx8HVSffff78sFos2btyoxo0bW9s7deqku+++24GV2frzz7FVq1a65pprdN1116lPnz5KTk7WPffc4+AK//DnOuuyulzn/fffrwYNGmjTpk02fyfbtm2rAQMGVO3bqIEa9NxzzykpKUmLFi3Srbfe6uhy6hyuANWwJUuWqEOHDgoODtadd96p+fPn1/l/GAsKCvTOO++offv2atGihaPL0YkTJ5SamqqxY8fa/KIpU1Pf22Yvf//739WlSxctXbrU0aXATo4fP67Vq1dX+ndSkt2+SBmojkceeURPPPGEVqxYQfipBAGohs2bN0933nmnpD8u5+fl5enLL790cFXlrVixQk2aNFGTJk3k4eGhjz/+WIsXL7b5GhJH2bNnjwzDUIcOHRxdSrV16NBBWVlZji7D6s/vd9n29NNPO7qscv5a57k+Ab42lf2dDA4Otmn39va21vrII484qDpbFb3XMTExji4LNWjlypV67rnntHz5cvXp08fR5dRZ3AKrQbt27dLGjRv10UcfSZIaNGigwYMHa968eerVq5dji/uL3r17a/bs2ZKkkydP6rXXXlNMTIw2btyo1q1bO7S2un7FrCoMw6hTVwT+/H6Xad68uYOqqdxf66zsaktdsXHjRpWWlmrYsGEqKipydDmSKn6vN2zYYP0fM1x6QkJCdOzYMSUlJalbt25q0qSJo0uqkwhANWjevHk6e/asAgICrG2GYcjV1VWvvvqqvLy8HFidrcaNG6t9+/bW12+++aa8vLw0d+5cPfnkkw6sTLriiitksVi0c+dOh9ZxMXbs2FFnFu9K5d/vuqqu1tm+fXtZLBbt2rXLpr1t27aSJHd3d0eUVaGKfoYHDx50UDWoDa1atdIHH3yg3r17Kzo6WitXrpSHh4ejy6pzHH9/4xJ19uxZvfXWW5o+fboyMzOt2/fff6+AgIA6+cTNn1ksFjk5OenMmTOOLkXNmzdXVFSUZs2apcLCwnL76+KjvH+2du1a/fDDD7r99tsdXQrspEWLFurbt69effXVCv9OAo7WunVrffnll8rJyVF0dLROnz7t6JLqHK4A1ZAVK1bo5MmTGjVqVLkrPbfffrvmzZune++910HVlVdUVKScnBxJf9wCe/XVV1VQUKDY2FgHV/aHWbNm6frrr1e3bt00depUhYSE6OzZs1qzZo1mz56tHTt2OLpESf/7OZaUlCg3N1epqamaNm2a+vfvr+HDhzu6PKs/v99lGjRoIG9vbwdVVP+89tpruv7663Xttddq8uTJCgkJkZOTk7777jvt3LlTYWFhji4RJhcYGKj09HT17t1bUVFRSk1Nlaenp6PLssrLy1NmZqZNW4sWLRQYGFgr5ycA1ZB58+YpMjKywttct99+u5577jlt27ZNISEhDqiuvNTUVPn7+0uSPDw81KFDB73//vt1Zq1S27ZttWXLFj311FN66KGHlJ2dLR8fH4WFhZVb3+BIZT/HBg0aqFmzZurSpYtefvlljRgxok4sKC/z5/e7THBwcL2+zVjb2rVrp61bt+rpp59WYmKiDh48KFdXV3Xs2FEPP/yw7r//fkeXiBpSWlqqBg3qx6/Pyy67zCYErVq1qs6EoPT0dHXt2tWmbdSoUXrzzTdr5fwW41JYYQoAQC2Jjo5W+/bt9eqrrzq6FFyEuvO/pAAA1GEnT57UihUrlJ6ersjISEeXg4tUP67hAQDgYHfffbe+++47PfTQQxowYICjy8FF4hYYAAAwHW6BAQAA0yEAAQAA0yEAAQAA0yEAAQAA0yEAAagzevXqpXHjxtllrKysLFkslnKfNFsTqnKu9PR0WSyWOv/VLYBZ8Bg8gEtSYGCgsrOza+XrPWrzXADsgwAE4JLk7OwsPz+/S+5cAOyDW2AAHKKwsFDDhw9XkyZN5O/vr+nTp9vsLyoq0sMPP6xWrVqpcePGCg8PV3p6uiQpPz9f7u7uWrlypc0xH330kTw8PPTrr79WeFvqxx9/VP/+/eXp6SkPDw/16NFDe/fute5/8803ddVVV8nNzU0dOnTQa6+9VqW5VHSuzz77TFdeeaXc3d3Vu3dvZWVlXdDPB0DNIgABcIjx48fryy+/1PLly7V69Wqlp6dry5Yt1v3x8fHKyMjQokWLtG3bNg0aNEjR0dHavXu3PD091b9/f6WkpNiM+e6772rgwIFq1KhRufMdOnRIN954o1xdXbV27Vpt3rxZd999t86ePWs9dtKkSXrqqae0Y8cOPf3003r88ce1cOHCC57bgQMHdNtttyk2NlaZmZm655579Oijj17wOABqkAEAtez06dOGi4uLsWTJEmvb8ePHDXd3d+PBBx80fvnlF8PZ2dk4dOiQzXF9+vQxEhMTDcMwjI8++sho0qSJUVhYaBiGYeTl5Rlubm7GypUrDcMwjH379hmSjK1btxqGYRiJiYlGUFCQUVxcXGFN7dq1M1JSUmzannjiCSMiIuK886noXB07drTp88gjjxiSjJMnT553PAA1jzVAAGrd3r17VVxcrPDwcGtb8+bNFRwcLEn64YcfVFJSoiuvvNLmuKKiIrVo0UKS1K9fPzVs2FAff/yxhgwZog8//FCenp6VfkllZmamevTooYYNG5bbV1hYqL1792rUqFEaPXq0tf3s2bPy8vK64Pnt2LHDZm6SFBERccHjAKg5BCAAdU5BQYGcnZ21efNmOTs72+xr0qSJJMnFxUX/+Mc/lJKSoiFDhiglJUWDBw9WgwYV/7Pm7u5+zvNJ0ty5c8sFl7+eH8ClgQAEoNa1a9dODRs21IYNG3T55ZdLkk6ePKmffvpJPXv2VNeuXVVSUqIjR46oR48elY4zbNgw9e3bVz/++KPWrl2rJ598stK+ISEhWrhwoX7//fdyV4F8fX0VEBCgn3/+WcOGDbvo+V111VX6+OOPbdq+/fbbix4XgP2wCBpArWvSpIlGjRql8ePHa+3atdq+fbtGjhwpJ6c//km68sorNWzYMA0fPlxLly7Vvn37tHHjRk2bNk2ffvqpdZwbb7xRfn5+GjZsmIKCgspdvfmz+Ph45efna8iQIdq0aZN2796tt99+W7t27ZIkTZkyRdOmTdPLL7+sn376ST/88IMWLFigGTNmXPD87r33Xu3evVvjx4/Xrl27lJKSouTk5AseB0DNIQABcIjnn39ePXr0UGxsrCIjI3XDDTcoLCzMun/BggUaPny4HnroIQUHB2vgwIH67rvvrFeMJMlisWjo0KH6/vvvz3vlpkWLFlq7dq0KCgrUs2dPhYWFae7cudarQffcc4/efPNNLViwQJ07d1bPnj2VnJysoKCgC57b5Zdfrg8//FDLli1Tly5dNGfOHD399NMXPA6AmmMxDMNwdBEAAAC1iStAAADAdAhAAHAeTz/9tJo0aVLhFhMT4+jyAFQDt8AA4DxOnDihEydOVLjP3d1drVq1quWKAFwsAhAAADAdboEBAADTIQABAADTIQABAADTIQABAADTIQABAADTIQABAADTIQABAADTIQABAADT+X/y64gYzf8bDQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "sns.barplot(x='device_id', y='visit_count', data=features)\n",
+    "plt.title('Visit count per device');\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9bb87d9b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-06-20T01:06:51.219720Z",
+     "iopub.status.busy": "2025-06-20T01:06:51.219263Z",
+     "iopub.status.idle": "2025-06-20T01:06:51.290003Z",
+     "shell.execute_reply": "2025-06-20T01:06:51.288909Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'accuracy': 0.75, 'precision': 0.75, 'recall': 1.0, 'roc_auc': 1.0}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Train logistic regression\n",
+    "model, metrics = train(features[['visit_count', 'unique_pois']], (features['unique_pois'] > 1).astype(int))\n",
+    "metrics"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn>=0.27
 prefect>=2.13
 pandas>=2.0
 scikit-learn>=1.3
+matplotlib>=3.8
+seaborn>=0.13

--- a/src/ingestion/load_data.py
+++ b/src/ingestion/load_data.py
@@ -25,14 +25,28 @@ def run(path: Optional[str] = None) -> pd.DataFrame:
     """
 
     if path is None:
-        # Create a tiny example data set
-        return pd.DataFrame(
-            {
-                "device_id": ["A", "A", "B", "B", "C"],
-                "timestamp": pd.date_range("2023-01-01", periods=5, freq="h"),
-                "poi_id": [1, 2, 1, 3, 4],
-            }
-        )
+        # Create a small synthetic data set with multiple devices so that
+        # model evaluation techniques have enough samples.
+        frames = []
+        devices = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"]
+        for device_id in devices:
+            frames.append(
+                pd.DataFrame(
+                    {
+                        "device_id": [device_id, device_id],
+                        "timestamp": pd.date_range(
+                            "2023-01-01", periods=2, freq="h"
+                        ),
+                        "poi_id": (
+                            [1, 2]
+                            if device_id not in {"J", "K", "L"}
+                            else [1, 1]
+                        ),
+                    }
+                )
+            )
+
+        return pd.concat(frames, ignore_index=True)
 
     csv_path = Path(path)
     if not csv_path.exists():

--- a/src/modeling/opti_shift.py
+++ b/src/modeling/opti_shift.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Dict, Tuple
 
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
 
 
 def train(
-    features: pd.DataFrame, target: pd.Series
-) -> Tuple[LogisticRegression, float]:
-    """Train a logistic regression model.
+    features: pd.DataFrame,
+    target: pd.Series,
+    test_size: float = 0.2,
+    random_state: int = 0,
+) -> Tuple[LogisticRegression, Dict[str, float]]:
+    """Train a logistic regression model with a holdout set.
 
     Parameters
     ----------
@@ -22,10 +25,39 @@ def train(
 
     Returns
     -------
-    model, accuracy
+    model : ``LogisticRegression``
+    metrics : dict
+        Dictionary containing ``accuracy``, ``precision``, ``recall`` and
+        ``roc_auc`` scores measured on the holdout set.
     """
 
+    from sklearn.metrics import (
+        accuracy_score,
+        precision_score,
+        recall_score,
+        roc_auc_score,
+    )
+    from sklearn.model_selection import StratifiedKFold, cross_val_predict
+
+    cv = StratifiedKFold(n_splits=3, shuffle=True, random_state=random_state)
     model = LogisticRegression(max_iter=100)
+
+    y_pred = cross_val_predict(model, features, target, cv=cv)
+    y_prob = cross_val_predict(
+        model,
+        features,
+        target,
+        cv=cv,
+        method="predict_proba",
+    )[:, 1]
+
     model.fit(features, target)
-    accuracy = model.score(features, target)
-    return model, accuracy
+
+    metrics = {
+        "accuracy": accuracy_score(target, y_pred),
+        "precision": precision_score(target, y_pred, zero_division=0),
+        "recall": recall_score(target, y_pred, zero_division=0),
+        "roc_auc": roc_auc_score(target, y_prob),
+    }
+
+    return model, metrics

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -25,8 +25,9 @@ def train(features):
 
 
 @task
-def log_metric(acc):
-    log_run("training_accuracy", acc)
+def log_metrics(metrics):
+    for name, value in metrics.items():
+        log_run(name, value)
 
 
 @task
@@ -45,14 +46,11 @@ def main_flow():
     """Orchestrate ingestion, training and deployment tasks."""
     visits = ingest()
     feats = feature_engineering(visits)
-    model, acc = train(feats)
-    log_metric(acc)
+    model, metrics = train(feats)
+    log_metrics(metrics)
     triggers(feats)
-codex/audit-and-clean-mediajohnd/data-science-projects-repository
     app = deploy(model)
     return app
-    deploy(model)
-main
 
 
 if __name__ == "__main__":

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -4,6 +4,11 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from orchestrator import main_flow  # noqa: E402
+from ingestion.load_data import run as ingest  # noqa: E402
+from features.engineer_features import run as engineer  # noqa: E402
+from modeling.opti_shift import train  # noqa: E402
+from scoring.api import create_app  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 from prefect.testing.utilities import prefect_test_harness  # noqa: E402
 
 
@@ -16,3 +21,31 @@ def test_flow_runs():
     with prefect_test_harness():
         app = main_flow()
     assert app is not None
+
+
+def test_individual_tasks():
+    visits = ingest()
+    assert {"device_id", "timestamp", "poi_id"}.issubset(visits.columns)
+
+    feats = engineer(visits)
+    assert {"device_id", "visit_count", "unique_pois"}.issubset(feats.columns)
+
+    model, metrics = train(
+        feats[["visit_count", "unique_pois"]],
+        (feats["unique_pois"] > 1).astype(int),
+    )
+    assert "accuracy" in metrics
+
+
+def test_predict_endpoint():
+    visits = ingest()
+    feats = engineer(visits)
+    model, _ = train(
+        feats[["visit_count", "unique_pois"]],
+        (feats["unique_pois"] > 1).astype(int),
+    )
+    app = create_app(model)
+    client = TestClient(app)
+    resp = client.post("/predict", json={"features": [1, 1]})
+    assert resp.status_code == 200
+    assert "probability" in resp.json()


### PR DESCRIPTION
## Summary
- execute `full_pipeline_summary.ipynb` showing ingestion, feature engineering and model metrics
- compute accuracy, precision, recall and ROC AUC in `modeling.opti_shift`
- log all metrics in `orchestrator`
- provide richer synthetic data for evaluation
- document notebook execution instructions
- add simple data flow diagram
- expand tests for task functions and API

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549f0a3c10832c8cedbc3776b74fa0